### PR TITLE
Fix: Correct theme initialization logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,12 +151,15 @@
             // Set initial language.
             setLanguage();
 
-            // The theme class is set by the script in the <head>. This part of the script
-            // simply ensures the UI (icons) and localStorage are synchronized with the
-            // current theme.
-            const currentTheme = htmlElement.classList.contains('dark') ? 'dark' : 'light';
-            // Calling setTheme ensures the icons and localStorage are correctly set on load.
-            setTheme(currentTheme);
+            // The theme class is already set by the script in the <head>.
+            // This part of the script simply ensures the UI (icons) are synchronized.
+            if (document.documentElement.classList.contains('dark')) {
+                themeIconLight.classList.add('hidden');
+                themeIconDark.classList.remove('hidden');
+            } else {
+                themeIconLight.classList.remove('hidden');
+                themeIconDark.classList.add('hidden');
+            }
         });
 
     </script>


### PR DESCRIPTION
The theme toggle was not correctly respecting your OS preference after the first visit.

The script on `DOMContentLoaded` was calling `setTheme()`, which immediately set a `theme` value in `localStorage`. This caused the OS preference to be ignored on all subsequent visits, as the `localStorage` value always took precedence.

The fix is to change the `DOMContentLoaded` listener to only synchronize the theme icons with the state already set by the script in the `<head>`. The `setTheme()` function, which writes to `localStorage`, is now only called when you explicitly click the toggle button. This ensures the OS preference is respected until you make a manual choice.